### PR TITLE
Rp/fix token refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pluto-headers",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Header components for pluto",
   "repository": "git://github.com/guardian/pluto-headers",
   "main": "build/index",

--- a/src/components/AppSwitcher/LoginComponent.tsx
+++ b/src/components/AppSwitcher/LoginComponent.tsx
@@ -58,7 +58,7 @@ const LoginComponent:React.FC<LoginComponentProps> = (props) => {
         return (()=>{
             window.clearInterval(intervalTimerId);
         })
-    }, []);
+    }, [userContext]);
 
     useEffect(()=>{
         if(refreshFailed) {


### PR DESCRIPTION
## What does this change?

After 30 minutes, the JWT was getting updated every minute. This was due to the usercontext not getting updated correctly - specifically the token expiry time.


## How was it fixed?

By adding `userContext` as a `useEffect` dependancy for `intervalTimerId`, every time `userContext` gets updated the timer is reset.

