### PR TITLE
Make static directory available when package is built

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pluto-headers",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "Header components for pluto",
   "repository": "git://github.com/guardian/pluto-headers",
   "main": "build/index",
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "test": "jest --verbose",
-    "build": "rm -rf build && rollup -c",
+    "build": "rm -rf build && rollup -c && mkdir build/static && cp src/static/* build/static/",
     "update-interfaces": "ts-interface-builder src/utils/OAuthConfiguration.ts"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pluto-headers",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Header components for pluto",
   "repository": "git://github.com/guardian/pluto-headers",
   "main": "build/index",


### PR DESCRIPTION
## What does this change?
- Bumps the package version to 2.0.3
- Copies the contents of `src/static` to `build/static` so that the `.svg` icons are available when the package is imported.