### PR TITLE
Adding Help Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pluto-headers",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Header components for pluto",
   "repository": "git://github.com/guardian/pluto-headers",
   "main": "build/index",

--- a/src/components/AppSwitcher/LoginComponent.tsx
+++ b/src/components/AppSwitcher/LoginComponent.tsx
@@ -169,10 +169,11 @@ const LoginComponent:React.FC<LoginComponentProps> = (props) => {
             <Grid item>
                 <Tooltip title="Open help page">
                     <Button
-                        className="login-button"
+                        className="help-button"
                         variant="outlined"
                         size="small"
                         onClick={openDocs}
+                        style={{  marginLeft: "10px", borderColor: "black", color: "black" }}
                     >
                       Help
                     </Button>

--- a/src/components/AppSwitcher/LoginComponent.tsx
+++ b/src/components/AppSwitcher/LoginComponent.tsx
@@ -135,7 +135,7 @@ const LoginComponent:React.FC<LoginComponentProps> = (props) => {
 
     const toggleThemeMode = ()=>themeContext.changeDarkMode(!themeContext.darkMode);
     const openDocs = ()=> window.open(
-        "https://docs.google.com/document/d/1QG9mOu_HDBoGqQs7Dly0sxifk4w9vaJiDiWdi3Uk1a8",
+        "pluto-core/help",
         "_blank"
     )
 
@@ -167,10 +167,15 @@ const LoginComponent:React.FC<LoginComponentProps> = (props) => {
                 </Tooltip>
             </Grid>
             <Grid item>
-                <Tooltip title="Open pluto guide">
-                    <IconButton onClick={openDocs} className={classes.iconButton}>
-                        <HelpOutline style={{color: themeContext.darkMode ? "rgba(0,0,0,0.54)" : "inherit" }}/>
-                    </IconButton>
+                <Tooltip title="Open help page">
+                    <Button
+                        className="login-button"
+                        variant="outlined"
+                        size="small"
+                        onClick={openDocs}
+                    >
+                      Help
+                    </Button>
                 </Tooltip>
             </Grid>
             {


### PR DESCRIPTION
## What does this change?

Adds a help button which links to the help page in pluto-core.

## How can we measure success?

The button exists and works.

## Images

![PH3](https://github.com/user-attachments/assets/6475bd60-74ad-4ec4-a60a-5fb96533ac39)

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2.